### PR TITLE
 _pha_err_, _emin_, _einc_ and _epha_ are not correctly computed

### DIFF
--- a/ttide/t_tide.py
+++ b/ttide/t_tide.py
@@ -625,7 +625,7 @@ def t_tide(xin, **kwargs):
             errval = np.multiply(
                       np.median(
                        np.absolute(
-                        fmaj-(np.median(fmaj, 1).reshape(-1, 1) *
+                        para-(np.median(para, 1).reshape(-1, 1) *
                               np.ones([1, nreal]))), 1)/0.6375, 1.96)
             return errval
 


### PR DESCRIPTION
First of all, thank you very much for your great contribution. I commonly use the t_tide script for harmonic analysis and like python. When I found your script I really felt happy. Working with phases, I found phase_error, _pha_err_, but also _emin_, _einc_ and _epha_ are not correctly computed. The function that compute the error doesn't pass the input variable.