### PR TITLE
Errcalc fixes

### DIFF
--- a/ttide/tests/print_tests.py
+++ b/ttide/tests/print_tests.py
@@ -1,6 +1,6 @@
 from ttide.t_tide import t_tide
 import ttide.tests.base as bmod
-from cStringIO import StringIO
+from io import StringIO
 import sys
 import numpy as np
 

--- a/ttide/tests/tide_tests.py
+++ b/ttide/tests/tide_tests.py
@@ -9,8 +9,43 @@ def test_errcalc():
     """
     errcalc_opts = ("cboot", "linear", "none")
 
+
+    con_cboot = None
+
+    msg_format = """
+
+    {} should be the same for all errcalc values.
+    But:
+    errcalc={}, yields mean {}={}
+    and
+    errcalc={}, yields mean {}={}
+    """
+
+
     for errcalc in errcalc_opts:
-        tt.t_tide(base.ein, dt=1., synth=0, ray=0.5, out_style=None, errcalc=errcalc)
+        con = tt.t_tide(base.ein, dt=1., synth=0, ray=0.5, out_style=None, errcalc=errcalc)
+
+        print(con["tidecon"])
+
+        if con_cboot is None:
+            con_cboot = con
+            amp_mean_cboot = con_cboot["tidecon"][:, 0].mean()
+            pha_mean_cboot = con_cboot["tidecon"][:, 2].mean()
+        else:
+            # amplitude and phase should not change
+            amp_mean = con["tidecon"][:, 0].mean()
+            pha_mean = con["tidecon"][:, 2].mean()
+
+
+
+
+            param = "amplitude"
+            msg = msg_format.format(param, errcalc, param, amp_mean, errcalc_opts[0], param, amp_mean_cboot)
+            assert amp_mean == amp_mean_cboot, msg
+
+            param = "phase"
+            msg = msg_format.format(param, errcalc, param, pha_mean, errcalc_opts[0], param, pha_mean_cboot)
+            assert pha_mean == pha_mean_cboot, msg
 
 
 def test_all():

--- a/ttide/tests/tide_tests.py
+++ b/ttide/tests/tide_tests.py
@@ -1,5 +1,9 @@
 from ttide.tests import base
 import ttide as tt
+import logging
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 def test_errcalc():
@@ -48,7 +52,23 @@ def test_errcalc():
             assert pha_mean == pha_mean_cboot, msg
 
 
+def test_errcalc_same():
+    """
+    Make sure constituents are the same for different errcalc_opts
+    """
+
+    errcalc_opts = ("cboot", "linear", "none")
+
+    for errcalc in errcalc_opts:
+        tc = tt.t_tide(base.ein, dt=1., synth=0, ray=0.5, errcalc=errcalc)
+
+        logger.debug(tc)
+
+        raise Exception
+
+
 def test_all():
+    test_errcalc_same()
     test_errcalc()
 
 

--- a/ttide/tests/tide_tests.py
+++ b/ttide/tests/tide_tests.py
@@ -1,0 +1,21 @@
+from ttide.tests import base
+import ttide as tt
+
+
+def test_errcalc():
+    """
+    test different values for errcalc
+    should not fail
+    """
+    errcalc_opts = ("cboot", "linear", "none")
+
+    for errcalc in errcalc_opts:
+        tt.t_tide(base.ein, dt=1., synth=0, ray=0.5, out_style=None, errcalc=errcalc)
+
+
+def test_all():
+    test_errcalc()
+
+
+if __name__ == '__main__':
+    test_all()


### PR DESCRIPTION
Hi:

I needed to run ttide for a large number of points and thought maybe it would be faster to use linear error calculation or maybe disable it. I have added some code so that the linear option, as well as 'none' option, work.

Cheers