### PR TITLE
A few optimisations for t_vuf and t_getconsts

### DIFF
--- a/ttide/t_getconsts.py
+++ b/ttide/t_getconsts.py
@@ -78,10 +78,11 @@ def t_getconsts(ctime):
         ii = np.isfinite(const['ishallow'])
         const['freq'][~ii] = np.dot(const['doodson'][~ii, :], ader) / 24
 
+        shallow_m1 = const['ishallow'].astype(int) -1
+        iname_m1 = shallow['iname'].astype(int) -1
+        range_cache = {n:np.arange(n) for n in range(const['nshallow'].max()+1)}
         for k in np.flatnonzero(ii):
-            ik = ((const['ishallow'][k] - 1 +
-                   np.array(range(0, const['nshallow'][k]))).astype(int))
-            const['freq'][k] = np.dot(const['freq'][shallow['iname'][ik] - 1],
-                                      shallow['coef'][ik])
+            ik = shallow_m1[k] + range_cache[const['nshallow'][k]]
+            const['freq'][k] = const['freq'][iname_m1[ik]].dot(shallow['coef'][ik])
 
     return const, sat, shallow

--- a/ttide/t_vuf.py
+++ b/ttide/t_vuf.py
@@ -98,14 +98,17 @@ def t_vuf(ltype, ctime, ju, lat=None):
 
             # Compute amplitude and phase corrections
             # for shallow water constituents.
+            shallow_m1  = const['ishallow'].astype(int) -1
+            iname_m1    = shallow['iname'].astype(int) -1
+            coefs       = shallow['coef'].astype(np.float64)
+            range_cache = {n:np.arange(n) for n in range(const['nshallow'].max()+1)}
             for k in np.flatnonzero(np.isfinite(const['ishallow'])):
-                ik = ((const['ishallow'][k] - 1 +
-                       np.array(range(0, const['nshallow'][k]))).astype(int))
-                iname = shallow['iname'][ik] - 1
-                coef = shallow['coef'][ik]
-                f[k] = np.prod(np.power(f[iname], coef))
-                u[k] = np.dot(u[iname], coef)
-                v[k] = np.dot(v[iname], coef)
+                ik = shallow_m1[k] + range_cache[const['nshallow'][k]]
+                iname = iname_m1[ik]
+                coef = coefs[ik]
+                f[k] = np.multiply.reduce(np.power(f[iname], coef))
+                u[k] = u[iname].dot(coef)
+                v[k] = v[iname].dot(coef)
 
             f = f[ju]
             u = u[ju]


### PR DESCRIPTION
1. Cache the calls to range to avoid repeated calls it in the loop
2. Cache shallow & iname in int64 form with one subtracted to save work in the loop
3. Cache coef in float64 form to avoid this conversion in the loop
4. Change np.prod() to np.multiply.reduce()
5. Change np.dot() to ndarray.dot()