### PR TITLE
Change version to a tag that is valid according to PEP 440.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
         return f.read()
 
 setup(name='ttide',
-      version='0.3_exp',
+      version='0.3.0',
       description='Python distribution of the MatLab package TTide.',
       long_description=readme(),
       url='https://github.com/moflaher/ttide_py',


### PR DESCRIPTION
Version `0.3_exp` is not valid according to PEP 440. Thus, I changed it to `0.3.0` and it worked.