### PR TITLE
Fix ValueError for newer numpy versions

### DIFF
--- a/ttide/t_tide.py
+++ b/ttide/t_tide.py
@@ -427,7 +427,7 @@ def t_tide(xin, dt=1, stime=None, lat=None,
     # would be to change the basis functions.
     ####################################################################
     ii = np.flatnonzero(np.isfinite(jref))
-    if ii:
+    if ii.size > 0:
         print('   Do inference corrections\\n')
         snarg = nobsu * pi * dt * (fi[(ii - 1)] - fu[(jref[(ii - 1)] - 1)])
         scarg = np.sin(snarg) / snarg


### PR DESCRIPTION
For newer Numpy versions, there's a `ValueError` from  https://github.com/moflaher/ttide_py/blob/60b10119e0d984aa2502d4075fd5267ec703491e/ttide/t_tide.py#L430

with the followig recommended fix: `ValueError: The truth value of an empty array is ambiguous. Use `array.size > 0` to check that an array is not empty.`

This PR applies the suggested fix.