### PR TITLE
Add a numpy.any() to an array evaluation

### DIFF
--- a/ttide/t_tide.py
+++ b/ttide/t_tide.py
@@ -427,7 +427,7 @@ def t_tide(xin, dt=1, stime=None, lat=None,
     # would be to change the basis functions.
     ####################################################################
     ii = np.flatnonzero(np.isfinite(jref))
-    if ii:
+    if np.any(ii):
         print('   Do inference corrections\\n')
         snarg = nobsu * pi * dt * (fi[(ii - 1)] - fu[(jref[(ii - 1)] - 1)])
         scarg = np.sin(snarg) / snarg


### PR DESCRIPTION
I'm using a fairly new version of Python (3.12.4), and get an error on line 430 about the ambiguity of the truth value of an empty array.  Wrapping the array in numpy.any() resolves the issue.